### PR TITLE
cppbar

### DIFF
--- a/hyperEmbed.py
+++ b/hyperEmbed.py
@@ -434,7 +434,7 @@ class DynamicHyperEmbed:
 
     def save(self, file_path):
         os.makedirs(file_path, exist_ok=True)
-        pbar = tqdm(self.models)
+        pbar = tqdm(self.models, leave=False)
         for key in pbar:
             torch.save(
                 self.models[key].state_dict(),

--- a/hyperEmbed.py
+++ b/hyperEmbed.py
@@ -409,7 +409,7 @@ class DynamicHyperEmbed:
                     },
                     os.path.join(checkpoint_dir, "epoch_{}".format(epoch), "train_env.pkl")
                 )
-                self.save(os.path.join(checkpoint_dir, "epoch_{}".format(epoch)))
+                self.save(os.path.join(checkpoint_dir, "epoch_{}".format(epoch)), leave_pbar=False)
     
     def resume_train_from_checkpoint(self, checkpoint_dir: str, dataset: DynamicHypergraphDataset):
         train_env = torch.load(os.path.join(checkpoint_dir, "train_env.pkl"))
@@ -432,9 +432,9 @@ class DynamicHyperEmbed:
             global_steps=train_env["global_steps"]
         )
 
-    def save(self, file_path):
+    def save(self, file_path, leave_pbar=True):
         os.makedirs(file_path, exist_ok=True)
-        pbar = tqdm(self.models, leave=False)
+        pbar = tqdm(self.models, leave=leave_pbar)
         for key in pbar:
             torch.save(
                 self.models[key].state_dict(),


### PR DESCRIPTION
Minor tweak so that when checkpoints save, the progress bars don't stack up and clutter the training UI. Off by default so it doesn't change behavior in manual calls to `.save()`.